### PR TITLE
feat: Create new users with docker and incus groups automatically via adduser

### DIFF
--- a/mkosi.finalize
+++ b/mkosi.finalize
@@ -15,4 +15,4 @@ echo "{\"ip-forward-no-drop\": true }" > "$BUILDROOT/usr/share/factory/etc/docke
 
 # Adjust default settings for adduser to include incus and docker groups automatically
 sed -i '/^#ADD_EXTRA_GROUPS=0$/c\ADD_EXTRA_GROUPS=1' "$BUILDROOT/usr/share/factory/etc/adduser.conf"
-sed -i '/^#EXTRA_GROUPS="users"$/c\EXTRA_GROUPS="users docker incus"' "$BUILDROOT/usr/share/factory/etc/adduser.conf"
+sed -i '/^#EXTRA_GROUPS="users"$/c\EXTRA_GROUPS="users docker incus-admin"' "$BUILDROOT/usr/share/factory/etc/adduser.conf"


### PR DESCRIPTION
Modifies default adduser.conf to always make new users with the users group, and docker + incus groups.

gnome-initial-setup calls this on debian based distros, and this change will also function for accounts made from the CLI.

Fixes #26 