### PR TITLE
chore: remove plymouth

### DIFF
--- a/mkosi.conf
+++ b/mkosi.conf
@@ -30,6 +30,8 @@ Output=%i_%v_%a
 [Content]
 BaseTrees=%O/base
 UnifiedKernelImageFormat=%i_%v_%a
+# as much as you want to enable plymouth and add `quiet splash` to the kernel cmdline
+# you can't because systemd-firstboot will prompt for input on first boot
 KernelCommandLine=
         root=dissect
         mount.usr=dissect

--- a/mkosi.conf.d/01-desktop.conf
+++ b/mkosi.conf.d/01-desktop.conf
@@ -19,8 +19,6 @@ Packages=
         modemmanager
         network-manager
         pipewire-pulse
-        plymouth
-        plymouth-themes
         steam-devices
         tuned-ppd
         va-driver-all

--- a/mkosi.images/base/mkosi.conf.d/01-desktop.conf
+++ b/mkosi.images/base/mkosi.conf.d/01-desktop.conf
@@ -19,7 +19,6 @@ Packages=
         modemmanager
         network-manager
         pipewire-pulse
-        plymouth-themes
         steam-devices
         tuned-ppd
         va-driver-all


### PR DESCRIPTION
because we can't use it as long as we're using systemd-firstboot